### PR TITLE
Added function unchanged_cert to reflect changes in letsencrypt.sh

### DIFF
--- a/pdns-acme
+++ b/pdns-acme
@@ -45,6 +45,10 @@ function deploy_cert {
     done
 }
 
+function unchanged_cert {
+    // When the cert does not change, nothing needs to be done.
+}
+
 exit_error() {
   echo "ERROR: ${1}" >&2
   exit 1
@@ -60,7 +64,7 @@ function resolv_config() {
     else
         exit_error "Config file not found."
     fi
-    
+
     if ! jq . "$CONFIG" >/dev/null 2>&1
     then
         exit_error "Parsing error in config file."
@@ -140,5 +144,3 @@ elif [ $HANDLER = deploy_cert ]
 then
     $HANDLER $@
 fi
-
-


### PR DESCRIPTION
The call to the hook script changed in letsencrypt.sh. 
If a certificate is unchanged, the unchanged_cert function of the hook script is called. 

As we don't need to do anything and the information that the certificate didn't chane is already printed by letsencrypt.sh, the function is just empty.