### PR TITLE
Few improvments and added posibility for multiple IDS per domain - closes #6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 pdns-acme.json
 dehydrated.config
+certs

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 pdns-acme.json
+dehydrated.config

--- a/hook
+++ b/hook
@@ -1,38 +1,51 @@
 #!/usr/bin/env bash
 
 deploy_challenge() {
-    i=0
+    local PROCESSED="@"
     while [ $# -gt 0 ]
     do
         local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}"
 
         echo " - Deploying challenge for $DOMAIN"
 
-        ID=$(cat ../pdns-acme.json | jq -r ".domains[\"${DOMAIN}\"] | if type==\"array\" then .[${i}] else . end")
+        # if used already we assume this is the wildcard
+        if [ -z "${PROCESSED##*@${DOMAIN}@*}" ]; then
+            ID=$(cat ../pdns-acme.json | jq -r ".domains[\"*.${DOMAIN}\"]")
+        else
+            ID=$(cat ../pdns-acme.json | jq -r ".domains[\"${DOMAIN}\"]")
+        fi
         SERVER=$(cat ../pdns-acme.json | jq -r .config.server)
 
         ../pdns-client/pdns-client -s $SERVER -i $ID -c $TOKEN_VALUE
+        PROCESSED="${PROCESSED}${DOMAIN}@"
         
         shift 3
-        i=$((i+1))
     done
     sleep $(cat ../pdns-acme.json | jq -r '.config."deploy-wait"')
 }
 
 clean_challenge() {
-    i=0
+    local PROCESSED="@"
     while [ $# -gt 0 ]
     do
         local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}"
 
         echo " - Cleaning challenge for $DOMAIN"
 
-        ID=$(cat ../pdns-acme.json | jq -r ".domains[\"${DOMAIN}\"] | if type==\"array\" then .[${i}] else . end")
+        # if used already we assume this is the wildcard
+        if [ -z "${PROCESSED##*@${DOMAIN}@*}" ]; then
+            ID=$(cat ../pdns-acme.json | jq -r ".domains[\"*.${DOMAIN}\"]")
+            SUFFIX=1
+        else
+            ID=$(cat ../pdns-acme.json | jq -r ".domains[\"${DOMAIN}\"]")
+            SUFFIX=
+        fi
         SERVER=$(cat ../pdns-acme.json | jq -r .config.server)
 
-        ../pdns-client/pdns-client -s $SERVER -i $ID -c none${i}
+        ../pdns-client/pdns-client -s $SERVER -i $ID -c none${SUFFIX}
+        PROCESSED="${PROCESSED}${DOMAIN}@"
+
         shift 3
-        i=$((i+1))
     done
 }
 

--- a/hook
+++ b/hook
@@ -1,55 +1,54 @@
 #!/usr/bin/env bash
 
 deploy_challenge() {
-    local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}"
+    while [ $# -gt 0 ]
+    do
+        local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}"
 
-    echo " - Deploying challenge for $DOMAIN"
+        echo " - Deploying challenge for $DOMAIN"
 
-    ID=$(cat ../pdns-acme.json | jq -r '.domains["'$DOMAIN'"]')
-    SERVER=$(cat ../pdns-acme.json | jq -r .config.server)
+        ID=$(cat ../pdns-acme.json | jq -r '.domains["'$DOMAIN'"]')
+        SERVER=$(cat ../pdns-acme.json | jq -r .config.server)
 
-    ../pdns-client/pdns-client -s $SERVER -i $ID -c $TOKEN_VALUE
+        ../pdns-client/pdns-client -s $SERVER -i $ID -c $TOKEN_VALUE
+        
+        shift 3
+    done
+    sleep $(cat ../pdns-acme.json | jq -r '.config."deploy-wait"')
 }
 
 clean_challenge() {
-    local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}"
+    while [ $# -gt 0 ]
+    do
+        local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}"
 
-    echo " - Cleaning challenge for $DOMAIN"
+        echo " - Cleaning challenge for $DOMAIN"
 
-    ID=$(cat ../pdns-acme.json | jq -r '.domains["'$DOMAIN'"]')
-    SERVER=$(cat ../pdns-acme.json | jq -r .config.server)
+        ID=$(cat ../pdns-acme.json | jq -r '.domains["'$DOMAIN'"]')
+        SERVER=$(cat ../pdns-acme.json | jq -r .config.server)
 
-    ../pdns-client/pdns-client -s $SERVER -i $ID -c none
+        ../pdns-client/pdns-client -s $SERVER -i $ID -c none
+        shift 3
+    done
 }
 
 deploy_cert() {
-    local DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" FULLCHAINFILE="${4}" CHAINFILE="${5}" TIMESTAMP="${6}"
-
-    echo " - Deploying cert $DOMAIN"
-
-    cat ../pdns-acme.json | jq -r '.certs["'$DOMAIN'"].hook | (arrays | .[]),(strings)' | while read command
+    while [ $# -gt 0 ]
     do
-        $command
+        local DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" FULLCHAINFILE="${4}" CHAINFILE="${5}" TIMESTAMP="${6}"
+
+        echo " - Deploying cert $DOMAIN"
+
+        cat ../pdns-acme.json | jq -r '.certs["'$DOMAIN'"].hook | (arrays | .[]),(strings)' | while read command
+        do
+            $command
+        done
+        shift 6
     done
 
 }
 
 HANDLER="$1"; shift
 if [[ "${HANDLER}" =~ ^(deploy_challenge|clean_challenge|deploy_cert)$ ]]; then
-    while [ $# -gt 0 ]
-    do
-        "$HANDLER" "$@"
-
-        if [ $HANDLER == "deploy_challenge" ]
-        then
-            sleep $(cat ../pdns-acme.json | jq -r '.config."deploy-wait"')
-            shift 3
-        elif [ $HANDLER == "clean_challenge" ]
-        then
-            shift 3
-        elif [ $HANDLER == "deploy_cert" ]
-        then
-            shift 6
-        fi
-    done
+    "$HANDLER" "$@"
 fi

--- a/hook
+++ b/hook
@@ -30,7 +30,7 @@ clean_challenge() {
         ID=$(cat ../pdns-acme.json | jq -r ".domains[\"${DOMAIN}\"] | if type==\"array\" then .[${i}] else . end")
         SERVER=$(cat ../pdns-acme.json | jq -r .config.server)
 
-        ../pdns-client/pdns-client -s $SERVER -i $ID -c none
+        ../pdns-client/pdns-client -s $SERVER -i $ID -c none${i}
         shift 3
         i=$((i+1))
     done

--- a/hook
+++ b/hook
@@ -1,34 +1,38 @@
 #!/usr/bin/env bash
 
 deploy_challenge() {
+    i=0
     while [ $# -gt 0 ]
     do
         local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}"
 
         echo " - Deploying challenge for $DOMAIN"
 
-        ID=$(cat ../pdns-acme.json | jq -r '.domains["'$DOMAIN'"]')
+        ID=$(cat ../pdns-acme.json | jq -r ".domains[\"${DOMAIN}\"] | if type==\"array\" then .[${i}] else . end")
         SERVER=$(cat ../pdns-acme.json | jq -r .config.server)
 
         ../pdns-client/pdns-client -s $SERVER -i $ID -c $TOKEN_VALUE
         
         shift 3
+        i=$((i+1))
     done
     sleep $(cat ../pdns-acme.json | jq -r '.config."deploy-wait"')
 }
 
 clean_challenge() {
+    i=0
     while [ $# -gt 0 ]
     do
         local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}"
 
         echo " - Cleaning challenge for $DOMAIN"
 
-        ID=$(cat ../pdns-acme.json | jq -r '.domains["'$DOMAIN'"]')
+        ID=$(cat ../pdns-acme.json | jq -r ".domains[\"${DOMAIN}\"] | if type==\"array\" then .[${i}] else . end")
         SERVER=$(cat ../pdns-acme.json | jq -r .config.server)
 
         ../pdns-client/pdns-client -s $SERVER -i $ID -c none
         shift 3
+        i=$((i+1))
     done
 }
 

--- a/pdns-acme
+++ b/pdns-acme
@@ -40,7 +40,7 @@ check_domain_precence() {
     cat pdns-acme.json | jq -r '(.certs | to_entries[] | .key),(.certs[] | .alias | arrays | .[])' | while read domain
     do
         res=$(cat pdns-acme.json | jq .domains[\"$domain\"])
-        if [ $res == "null" ]
+        if [ "$res" == "null" ]
         then
             exit_error "No id configured for domain $domain"
         fi

--- a/pdns-acme
+++ b/pdns-acme
@@ -15,10 +15,12 @@ init() {
 
     cd ..
 
+    setup_config
+
     cd dehydrated
 
     touch config
-    ./dehydrated --register --accept-terms
+    ./dehydrated -f ./config --register --accept-terms
 
     cd ..
 }
@@ -45,11 +47,7 @@ check_domain_precence() {
     done
 }
 
-cron() {
-    cat pdns-acme.json | jq -r '.certs | to_entries[] |
-        (.key + (if (.value.alias | length) > 0 then .value.alias | " " + join(" ") else "" end))' \
-    > dehydrated/domains.txt
-
+setup_config() {
     echo 'CERTDIR="${BASEDIR}/../certs"' > dehydrated/config
     echo 'HOOK_CHAIN="yes"' >> dehydrated/config
     echo 'HOOK="${BASEDIR}/../hook"' >> dehydrated/config
@@ -59,9 +57,17 @@ cron() {
     then
         cat dehydrated.config >> dehydrated/config
     fi
+}
+
+cron() {
+    cat pdns-acme.json | jq -r '.certs | to_entries[] |
+        (.key + (if (.value.alias | length) > 0 then .value.alias | " " + join(" ") else "" end))' \
+    > dehydrated/domains.txt
+
+    setup_config
 
     cd dehydrated
-    ./dehydrated -c
+    ./dehydrated -c -f ./config
     cd ..
 }
 


### PR DESCRIPTION
I've made a few minor improvments that resolve issue I've encountered. 
1. Instead of waiting between each deployment, make all the changes to pdns and them wait only once for the propagation. 
2. Added posibility to set multiple pdns record ids per domain and use them sequencually, so users can issue domains with wildcard like 'example.org *.example.org' 
3. If there was a dehydrated package installed calling even the checkout of dehydrated was still trying to use /var/lib/dehydrated as basedir, so I've explicitly call dehydrated with -f switch